### PR TITLE
Support mirror between clusters, using Kafka Streams

### DIFF
--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -21,9 +21,6 @@ services:
     - --override
     -   log.dirs=/var/lib/kafka/data/topics
     - --override
-    # Shouldn't be needed for streams, but currently for the test container(s) to produce data
-    -   auto.create.topics.enable=true
-    - --override
     -   default.replication.factor=1
     - --override
     -   min.insync.replicas=1
@@ -41,6 +38,43 @@ services:
     ports:
     - 19092:19092
 
+  destination-zookeeper:
+    image: solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
+    entrypoint: ./bin/zookeeper-server-start.sh
+    command:
+    - ./config/zookeeper.properties
+
+  destination-kafka:
+    image: solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
+    links:
+    - destination-zookeeper
+    entrypoint:
+    - ./bin/kafka-server-start.sh
+    - ./config/server.properties
+    - --override
+    -   zookeeper.connect=destination-zookeeper:2181
+    - --override
+    -   log.retention.hours=-1
+    - --override
+    -   log.dirs=/var/lib/kafka/data/topics
+    - --override
+    -   default.replication.factor=1
+    - --override
+    -   min.insync.replicas=1
+    - --override
+    -   offsets.retention.minutes=10080
+    # For access from dev environment
+    - --override
+    -   listeners=OUTSIDE://:19192,PLAINTEXT://:9092
+    - --override
+    -   advertised.listeners=OUTSIDE://localhost:19192,PLAINTEXT://:9092
+    - --override
+    -   listener.security.protocol.map=PLAINTEXT:PLAINTEXT,OUTSIDE:PLAINTEXT
+    - --override
+    -   inter.broker.listener.name=PLAINTEXT
+    ports:
+    - 19192:19192
+
   pixy:
     depends_on:
     - kafka
@@ -51,10 +85,47 @@ services:
     - -tcpAddr
     -  0.0.0.0:19090
 
+  topic1-create:
+    image: solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
+    depends_on:
+    - kafka
+    entrypoint:
+    - ./bin/kafka-topics.sh
+    command:
+    - --zookeeper
+    -   zookeeper:2181
+    - --topic
+    -   topic1
+    - --create
+    - --if-not-exists
+    - --partitions
+    -   '3'
+    - --replication-factor
+    -   '1'
+
+  destination-topic2-create:
+    image: solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
+    depends_on:
+    - destination-kafka
+    entrypoint:
+    - ./bin/kafka-topics.sh
+    command:
+    - --zookeeper
+    -   destination-zookeeper:2181
+    - --topic
+    -   topic2
+    - --create
+    - --if-not-exists
+    - --partitions
+    -   '3'
+    - --replication-factor
+    -   '1'
+
   copy1:
     image: yolean/kafka-topics-copy:dev
     depends_on:
     - kafka
+    - destination-kafka
     labels:
     - com.yolean.build-target
     environment:

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -38,21 +38,21 @@ services:
     ports:
     - 19092:19092
 
-  destination-zookeeper:
+  source-zookeeper:
     image: solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
     entrypoint: ./bin/zookeeper-server-start.sh
     command:
     - ./config/zookeeper.properties
 
-  destination-kafka:
+  source-kafka:
     image: solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
     links:
-    - destination-zookeeper
+    - source-zookeeper
     entrypoint:
     - ./bin/kafka-server-start.sh
     - ./config/server.properties
     - --override
-    -   zookeeper.connect=destination-zookeeper:2181
+    -   zookeeper.connect=source-zookeeper:2181
     - --override
     -   log.retention.hours=-1
     - --override
@@ -85,7 +85,7 @@ services:
     - -tcpAddr
     -  0.0.0.0:19090
 
-  topic1-create:
+  topic2-create:
     image: solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
     depends_on:
     - kafka
@@ -95,7 +95,7 @@ services:
     - --zookeeper
     -   zookeeper:2181
     - --topic
-    -   topic1
+    -   topic2
     - --create
     - --if-not-exists
     - --partitions
@@ -103,15 +103,15 @@ services:
     - --replication-factor
     -   '1'
 
-  destination-topic2-create:
+  source-topic1-create:
     image: solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
     depends_on:
-    - destination-kafka
+    - source-kafka
     entrypoint:
     - ./bin/kafka-topics.sh
     command:
     - --zookeeper
-    -   destination-zookeeper:2181
+    -   source-zookeeper:2181
     - --topic
     -   topic2
     - --create
@@ -125,7 +125,7 @@ services:
     image: yolean/kafka-topics-copy:dev
     depends_on:
     - kafka
-    - destination-kafka
+    - source-kafka
     labels:
     - com.yolean.build-target
     environment:

--- a/src/main/java/se/yolean/kafka/topicscopy/App.java
+++ b/src/main/java/se/yolean/kafka/topicscopy/App.java
@@ -20,7 +20,9 @@ public class App {
 
     props.put(StreamsConfig.APPLICATION_ID_CONFIG, options.getApplicationId());
 
-    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, options.getBootstrapServers());
+    //props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, options.getBootstrapServers());
+    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19192");
+    props.put(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19092");
 
     props.put(StreamsConfig.PRODUCER_PREFIX + ProducerConfig.ACKS_CONFIG, "all");
 

--- a/src/main/java/se/yolean/kafka/topicscopy/App.java
+++ b/src/main/java/se/yolean/kafka/topicscopy/App.java
@@ -22,7 +22,7 @@ public class App {
 
     //props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, options.getBootstrapServers());
     props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19192");
-    props.put(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19092");
+    props.put(StreamsConfig.PRODUCER_PREFIX + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19092");
 
     props.put(StreamsConfig.PRODUCER_PREFIX + ProducerConfig.ACKS_CONFIG, "all");
 


### PR DESCRIPTION
Continues from #1. Replacing mirror-maker whitelists with something microservice-ish would be a valuable use case for topics copy. However an experiment with bootstrap servers props reaches the same conclusion as https://stackoverflow.com/a/45851113